### PR TITLE
Portfolio: preserve data in the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,9 +130,9 @@
                     that needs coding. I’d love to help with it </p>
             </div>
             <form class="contact-form" action="https://formspree.io/f/mgedkazg" method="POST" id="contact-form">
-                <input class="name" type="text" maxlength="30" name="name" placeholder="Name" required />
-                <input class="email" type="email" name="email" placeholder="Email Address" required />
-                <textarea name="message" placeholder="Write your message here" maxlength="500" required></textarea>
+                <input class="name" type="text" maxlength="30" name="name" placeholder="Name" required oninput="handleValueChange(this)" />
+                <input class="email" type="email" name="email" placeholder="Email Address" required  oninput="handleValueChange(this)"/>
+                <textarea name="message" placeholder="Write your message here" maxlength="500" required oninput="handleValueChange(this)"></textarea>
                 <em id="error-message"></em>
                 <button class="submit-btn" type="submit">Get It Touch</button>
                 

--- a/index.js
+++ b/index.js
@@ -199,6 +199,9 @@ contactForm.addEventListener('submit', (event) => {
     document.forms[0].submit();
   }
 });
+
+// Handle the change of local storage
+
 const handleValueChange = (event) => {
   const formData = JSON.parse(localStorage.getItem('formData')) || {};
   formData[event.name] = event.value;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ window.dataLayer = window.dataLayer || [];
 function gtag(...args) { window.dataLayer.push(args); }
 gtag('js', new Date());
 gtag('config', 'G-ES0LN8KC8W');
-
+const contactForm = document.querySelector('#contact-form');
+const EMAIL_INVALID_CASE = 'Please enter email in  Lower  case';
+const errorElement = document.getElementById('error-message');
 const projects = [
   {
     id: 1,
@@ -68,6 +70,12 @@ const projects = [
 ];
 
 window.onload = (params) => {
+  const formData = JSON.parse(localStorage.getItem('formData'));
+  if (formData) {
+    contactForm.elements.name.value = formData.name;
+    contactForm.elements.email.value = formData.email;
+    contactForm.elements.message.value = formData.message;
+  }
   const workSection = document.getElementById('Portoflio');
   projects.forEach((project) => {
     const projectHTML = ` <div class="work-card"  id="${project.id}">
@@ -157,9 +165,7 @@ function closeProjectDetails() {
 }
 
 // Validate Contact Form Scripts
-const contactForm = document.querySelector('#contact-form');
-const EMAIL_INVALID_CASE = 'Please enter email in  Lower  case';
-const errorElement = document.getElementById('error-message');
+
 // show a message with a type of the input
 function showMessage(input, message, type) {
   errorElement.innerText += message;
@@ -193,3 +199,9 @@ contactForm.addEventListener('submit', (event) => {
     document.forms[0].submit();
   }
 });
+const handleValueChange = (event) => {
+  const formData = JSON.parse(localStorage.getItem('formData')) || {};
+  formData[event.name] = event.value;
+  localStorage.setItem('formData', JSON.stringify(formData));
+  console.log(formData);
+};


### PR DESCRIPTION
### Portfolio: preserve data in the browser

- When the user changes the content of any input field, the data is saved to the local storage.
- When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.
- Fixed  lint errors